### PR TITLE
Setup Docker for Frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# Trivia Party
+
+### How to run the project
+
+**Prerequities:**
+Make sure Docker Desktop is installed
+
+To run the entire project, simply run the following command on the CLI in the root of the project:
+
+```
+docker compose watch
+```
+
+This will run the frontend application on `localhost:5173`, and it will make use of Vite's HMR to automatically sync the changes you make in the code editor to the container.
+
+However, to run only the frontend service, navigate to the `frontend` folder and run the following command to build the frontend docker image:
+
+```
+docker build -t {tagName} -f Dockerfile.dev .
+```
+
+and run the container by doing:
+```
+docker run -p {hostPort}:5173 -d {tagName}
+```
+
+The frontend application will be running on `localhost:{hostPort}`.
+
+**Important caveat**: When using this approach and running only the frontend container, you will have to rebuild the image and rerun the container every time to see your changes, so running the entire application using docker compose is recommended.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile.dev
+    ports:
+      - "5173:5173"
+    develop:
+      watch:
+        - action: sync
+          path: ./frontend
+          target: /app/frontend
+          ignore:
+            - node_modules/
+        - action: rebuild
+          path: package.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+# TODO: create seperate service for frontend-prod
+
 services:
   frontend:
     build:

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+
+.gitignore
+
+Dockerfile
+.dockerignore
+docker-compose.yml

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:22-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+
+RUN npm ci
+
+COPY . .
+
+EXPOSE 5173
+
+CMD ["npm", "run", "dev"]

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -1,6 +1,6 @@
 FROM node:22-alpine
 
-WORKDIR /app
+WORKDIR /app/frontend
 
 COPY package*.json ./
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --host",
     "build": "tsc -b && vite build",
     "lint:fix": "eslint . --fix",
     "prettier:fix": "npx prettier --write .",


### PR DESCRIPTION
- Setup `Dockerfile.dev` in FE and `docker-compose.yml` in root
- Created README instructions for running the application
- To run the entire application (currently only frontend), run `docker compose watch` in the CLI in the root of the project, and frontend site should be running on `localhost:5173`

TODO: 
  - Create `Dockerfile` in FE folder for prod containers, current `Dockerfile.dev` is only for dev environment
  - Create `Dockerfile` for BE folder once it is ready, and add BE service to `docker-compose.yml` once ready